### PR TITLE
README et Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ Pour ce faire, il suffit simplement d'executer la commande:
 docker-compose up
 ```
 
-Ceci va télécharger l'image docker de [Jekyll](https://www.jekyll.io/) et installer les dépendances nécéssaire avant d'effectuer le rendu du site.
-Le résultat sera disponible sur <http://localhost:4000>. Les modifications sont automatiquement prises en compte et provoque un nouveau rendu du site.
+Ceci va télécharger l'image docker de [Jekyll](https://www.jekyll.io/) et installer les dépendances nécéssaires avant d'effectuer le rendu du site.
+Le résultat sera disponible sur <http://localhost:4000>. Les modifications sont automatiquement prises en compte et provoquent un nouveau rendu du site.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Documentation de data.gouv.fr
+
+Ce dépôt correspond au contenu du site doc.data.gouv.fr.
+
+## Contribuer
+
+**TODO**
+
+## Démarrage rapide
+
+### Ruby natif
+
+**TODO**
+
+### Docker Compose
+
+Vous pouvez utiliser [docker-compose](https://docs.docker.com/compose/) pour tester vos modifications localement avant de les soumettre.
+Pour ce faire, il suffit simplement d'executer la commande:
+
+```
+docker-compose up
+```
+
+Ceci va télécharger l'image docker de [Jekyll](https://www.jekyll.io/) et installer les dépendances nécéssaire avant d'effectuer le rendu du site.
+Le résultat sera disponible sur <http://localhost:4000>. Les modifications sont automatiquement prises en compte et provoque un nouveau rendu du site.

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,18 @@
 title: Data.gouv.fr Docs
-description: > 
-    La documentation du site data.gouv.fr 
+description: >
+    La documentation du site data.gouv.fr
 
 twitter_username: etalab
 github_username:  etalab
 
 sass:
     style: compressed
+
+
+exclude:
+  - README.md
+  - docker-compose.yml
+  - circle.yml
+  - deploy
+  - Gemfile
+  - Gemfile.lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  web:
+    image: jekyll/jekyll:latest
+    command: jekyll serve --watch --force_polling -H 0.0.0.0 -P 4000
+    ports:
+      - 4000:4000
+      - 35729:35729
+    volumes:
+      - $PWD:/srv/jekyll


### PR DESCRIPTION
Cette PR ajouter un squelette de README (à compléter) et un fichier docker-compose pour pouvoir tester facilement sur son propre poste.
Elle ignore aussi certains fichiers à la génération (les 2 fichiers ajouté mais aussi le script de déploiement, la conf circle, Gemfile...)
À compléter dans d'autres PRs