### PR TITLE
Précisions sur la procédure de déclaration d'un profil d'acheteur

### DIFF
--- a/_faq/profils-d-acheteur.md
+++ b/_faq/profils-d-acheteur.md
@@ -204,9 +204,9 @@ Vous trouverez un exemple de structure de fichier [sur data.gouv.fr](https://www
 « DECP » (données essentielles de la commande publique) afin de permettre la centralisation de l’ensemble des contributions par Etalab.</strong>
 
 La procédure complète pour déposer un ficher de déclaration de profil d‘acheteur sur data.gouv.fr est la suivante :
-1. créer un compte individuel via https://www.data.gouv.fr/fr/register ;
-2. une fois celui-ci validé via l‘email de confirmation, créer une organisation correspondant à votre profil d’acheteur via https://www.data.gouv.fr/fr/admin/organization/new/ ;
-3. créer un jeu de données via https://www.data.gouv.fr/fr/admin/dataset/new/ en choisissant lors de l‘étape « Choisissez qui publie » l‘organisation créée au point précédent ;
-4. à l‘étape « Décrivez votre jeu de données » renseigner un titre et éventuellement d'autres métadonnées (couverture spatiale, fréquence de mise à jour...) et **renseigner le tag (mot clé) « decp »** ;
-5. à l‘étape « Ajouter vos premières ressources » de la création du jeu de données, déposer le fichier CSV.
+1. Créer un compte individuel via https://www.data.gouv.fr/fr/register ;
+2. Une fois celui-ci validé via l‘email de confirmation, créer une organisation correspondant à votre profil d’acheteur via https://www.data.gouv.fr/fr/admin/organization/new/ ;
+3. Créer un jeu de données via https://www.data.gouv.fr/fr/admin/dataset/new/ en choisissant lors de l‘étape « Choisissez qui publie » l‘organisation créée au point précédent ;
+4. À l‘étape « Décrivez votre jeu de données » renseigner un titre et éventuellement d'autres métadonnées (couverture spatiale, fréquence de mise à jour...) et **renseigner le tag (mot clé) « decp »** ;
+5. À l‘étape « Ajouter vos premières ressources » de la création du jeu de données, déposer le fichier CSV.
 

--- a/_faq/profils-d-acheteur.md
+++ b/_faq/profils-d-acheteur.md
@@ -203,10 +203,10 @@ Vous trouverez un exemple de structure de fichier [sur data.gouv.fr](https://www
 <strong>Pour chaque fiche publiée il est essentiel de demander aux éditeurs de profils d’acheteurs d’associer le mot clé (« tag ») suivant :
 « DECP » (données essentielles de la commande publique) afin de permettre la centralisation de l’ensemble des contributions par Etalab.</strong>
 
-La procédure complète pour déposer un ficher de déclaration de profil d'acheteur sur data.gouv.fr est la suivante :
+La procédure complète pour déposer un ficher de déclaration de profil d‘acheteur sur data.gouv.fr est la suivante :
 1. créer un compte individuel via https://www.data.gouv.fr/fr/register ;
-2. une fois celui-ci validé via l’email de confirmation, créer une organisation correspondant à votre profil d’acheteur via https://www.data.gouv.fr/fr/admin/organization/new/ ;
-3. créer un jeu de données via https://www.data.gouv.fr/fr/admin/dataset/new/ en choisissant lors de l'étape « Choisissez qui publie » l'organisation créée au point précédent ;
-4. à l'étape « Décrivez votre jeu de données » renseigner un titre et éventuellement d'autres métadonnées (couverture spatiale, fréquence de mise à jour...) et **renseigner le tag (mot clé) « decp »** ;
-5. à l'étape « Ajouter vos premières ressources » de la création du jeu de données, déposer le fichier CSV.
+2. une fois celui-ci validé via l‘email de confirmation, créer une organisation correspondant à votre profil d’acheteur via https://www.data.gouv.fr/fr/admin/organization/new/ ;
+3. créer un jeu de données via https://www.data.gouv.fr/fr/admin/dataset/new/ en choisissant lors de l‘étape « Choisissez qui publie » l‘organisation créée au point précédent ;
+4. à l‘étape « Décrivez votre jeu de données » renseigner un titre et éventuellement d'autres métadonnées (couverture spatiale, fréquence de mise à jour...) et **renseigner le tag (mot clé) « decp »** ;
+5. à l‘étape « Ajouter vos premières ressources » de la création du jeu de données, déposer le fichier CSV.
 

--- a/_faq/profils-d-acheteur.md
+++ b/_faq/profils-d-acheteur.md
@@ -187,7 +187,7 @@ Exemples d’URL :
 
 La déclaration du profil d’acheteur est effectuée par l’acheteur ou toute personne habilitée par celui-ci sur le portail unique interministériel ([data.gouv.fr](https://data.gouv.fr)) destiné à rassembler et à mettre à disposition librement l’ensemble des informations publiques.
 
-L’objectif est d’impliquer les **éditeurs** de profils d’acheteurs afin de simplifier et rationnaliser la déclaration des profils d’acheteurs initialement confiée aux acheteurs publics. Dans le cas où l'éditeur n'est pas en mesure d'assurer la déclaration, le profil d'acheteur peut le faire directement.
+L’objectif est d’impliquer les **éditeurs** de profils d’acheteurs afin de simplifier et rationnaliser la déclaration des profils d’acheteurs initialement confiée aux acheteurs publics. Dans le cas où l’éditeur n'est pas en mesure d'assurer la déclaration, l’administrateur du profil d'acheteur ou l’acheteur peut le faire directement.
 
 ### Comment déclarer ?
 

--- a/_faq/profils-d-acheteur.md
+++ b/_faq/profils-d-acheteur.md
@@ -189,7 +189,7 @@ L’objectif est d’impliquer les **éditeurs** de profils d’acheteurs afin d
 
 #### Format de fichier
 
-Les éditeurs de profil d’acheteur sont à créer un fichier au format .CSV contenant les informations suivantes :
+Les éditeurs de profil d’acheteur sont invités à créer un fichier au format .CSV contenant les informations suivantes :
 
   * le SIRET des acheteurs (colonne `siretAcheteur`)
   * l'adresse URL des profils d'acheteurs (colonne `urlProfilAcheteur`)

--- a/_faq/profils-d-acheteur.md
+++ b/_faq/profils-d-acheteur.md
@@ -4,6 +4,10 @@ subtitle: En tant que profil d’acheteur
 label: En tant que profil d’acheteur
 ---
 # Comment remplir les obligations légales des profils d’acheteur ?
+{:.no_toc}
+
+* TOC
+{:toc}
 
 ## Un peu de contexte
 

--- a/_faq/profils-d-acheteur.md
+++ b/_faq/profils-d-acheteur.md
@@ -179,11 +179,17 @@ Exemples d’URL :
 
 ## Déclaration d’un profil d’acheteur
 
+### Qui doit déclarer ?
+
 La déclaration du profil d’acheteur est effectuée par l’acheteur ou toute personne habilitée par celui-ci sur le portail unique interministériel ([data.gouv.fr](https://data.gouv.fr)) destiné à rassembler et à mettre à disposition librement l’ensemble des informations publiques.
 
-L’objectif est d’impliquer les éditeurs de profils d’acheteurs afin de simplifier et rationnaliser la déclaration des profils d’acheteurs initialement confiée aux acheteurs publics.
+L’objectif est d’impliquer les **éditeurs** de profils d’acheteurs afin de simplifier et rationnaliser la déclaration des profils d’acheteurs initialement confiée aux acheteurs publics. Dans le cas où l'éditeur n'est pas en mesure d'assurer la déclaration, le profil d'acheteur peut le faire directement.
 
-Les éditeurs de profil d’acheteur sont invités à se créer un compte sur la plateforme data.gouv.fr afin d’y publier au format .CSV un fichier contenant les informations suivantes :
+### Comment déclarer ?
+
+#### Format de fichier
+
+Les éditeurs de profil d’acheteur sont à créer un fichier au format .CSV contenant les informations suivantes :
 
   * le SIRET des acheteurs (colonne `siretAcheteur`)
   * l'adresse URL des profils d'acheteurs (colonne `urlProfilAcheteur`)
@@ -192,7 +198,15 @@ Les éditeurs de profil d’acheteur sont invités à se créer un compte sur la
 
 Vous trouverez un exemple de structure de fichier [sur data.gouv.fr](https://www.data.gouv.fr/fr/datasets/structure-du-fichier-de-declaration-de-profil-dacheteur/#).
 
+#### Dépôt sur data.gouv.fr
+
 <strong>Pour chaque fiche publiée il est essentiel de demander aux éditeurs de profils d’acheteurs d’associer le mot clé (« tag ») suivant :
 « DECP » (données essentielles de la commande publique) afin de permettre la centralisation de l’ensemble des contributions par Etalab.</strong>
 
-Un modèle de fichier est disponible sur la page suivante : https://www.data.gouv.fr/fr/datasets/structure-du-fichier-de-declaration-de-profil-dacheteur/
+La procédure complète pour déposer un ficher de déclaration de profil d'acheteur sur data.gouv.fr est la suivante :
+1. créer un compte individuel via https://www.data.gouv.fr/fr/register ;
+2. une fois celui-ci validé via l’email de confirmation, créer une organisation correspondant à votre profil d’acheteur via https://www.data.gouv.fr/fr/admin/organization/new/ ;
+3. créer un jeu de données via https://www.data.gouv.fr/fr/admin/dataset/new/ en choisissant lors de l'étape « Choisissez qui publie » l'organisation créée au point précédent ;
+4. à l'étape « Décrivez votre jeu de données » renseigner un titre et éventuellement d'autres métadonnées (couverture spatiale, fréquence de mise à jour...) et **renseigner le tag (mot clé) « decp »** ;
+5. à l'étape « Ajouter vos premières ressources » de la création du jeu de données, déposer le fichier CSV.
+


### PR DESCRIPTION
L'objectif de cette PR est de prendre par la main des utilisateurs absolument pas familiers avec la plateforme et de centraliser toutes les informations nécessaires à la déclaration d'un profil d'acheteur.