### PR TITLE
Add redirect plugin w/ an example

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "jekyll"
 gem "jekyll-theme-gouvfr"
+gem "jekyll-redirect-from"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,8 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-redirect-from (0.14.0)
+      jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-theme-gouvfr (0.0.4)
@@ -60,7 +62,8 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  jekyll-redirect-from
   jekyll-theme-gouvfr
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/_config.yml
+++ b/_config.yml
@@ -69,3 +69,6 @@ defaults:
       layout: page
 
 theme: jekyll-theme-gouvfr
+
+plugins:
+  - jekyll-redirect-from

--- a/articles/_faq/profils-d-acheteur.md
+++ b/articles/_faq/profils-d-acheteur.md
@@ -2,6 +2,8 @@
 title: Comment remplir les obligations légales des profils d’acheteur ?
 subtitle: En tant que profil d’acheteur
 label: En tant que profil d’acheteur
+redirect_from:
+  - /faq/profils-d-acheteur.html
 ---
 # Comment remplir les obligations légales des profils d’acheteur ?
 {:.no_toc}
@@ -213,4 +215,3 @@ La procédure complète pour déposer un ficher de déclaration de profil d‘ac
 3. Créer un jeu de données via <https://www.data.gouv.fr/fr/admin/dataset/new/> en choisissant lors de l‘étape « Choisissez qui publie » l‘organisation créée au point précédent ;
 4. À l‘étape « Décrivez votre jeu de données » renseigner un titre et éventuellement d'autres métadonnées (couverture spatiale, fréquence de mise à jour...) et **renseigner le tag (mot clé) « decp »** ;
 5. À l‘étape « Ajouter vos premières ressources » de la création du jeu de données, déposer le fichier CSV.
-


### PR DESCRIPTION
We recently broke legacy URLs and some of them have been communicated to customers. This PR adds a redirect mechanism and deals with the `profils-d-acheteur` page as an example.

Cf https://github.com/jekyll/jekyll-redirect-from for instructions.