### PR TITLE
Modifie les niveaux de titre d’un article

### DIFF
--- a/articles/_reutilisations-et-discussions/associer-une-reutilisation-a-un-jeu-de-donnees.md
+++ b/articles/_reutilisations-et-discussions/associer-une-reutilisation-a-un-jeu-de-donnees.md
@@ -23,30 +23,30 @@ Pour référencer une réutilisation :
 2. Rendez-vous sur la page du jeu de données réutilisé ;
 3. Naviguez jusqu’à la section **Réutilisations** qui figure en bas de la page et cliquez sur **Ajouter une réutilisation** ;
 
-### 1. Choisir qui publie
+## 1. Choisir qui publie
 
 Choisissez si vous souhaitez publier la réutilisation sous votre propre nom, à titre individuel, ou pour le compte d’une organisation, à titre collectif. C’est le nom qui apparaîtra à côté de la réutilisation sur la page du jeu de données.
 
-### 2. Décrire la réutilisation
+## 2. Décrire la réutilisation
 
 Pour bien décrire la réutilisation, remplissez les champs suivants :
 
-**Nom**
+### Nom
 C’est le titre de la réutilisation. Précisez quelle forme prend la réutilisation : carte, graphique, tableau…
 
 Le nom est obligatoire.
 
-**URL**
+### URL
 Saisissez ici le lien hypertexte de la page web sur laquelle la réutilisation est visible.
 
 L’URL est obligatoire.
 
-**Type**
+### Type
 Indiquez le type dans lequel ranger la réutilisation.
 
 Le type est obligatoire.
 
-**Description**
+### Description
 Saisissez ici des précisions sur :
 
 * la méthode de création de la réutilisation (les outils et traitements utilisés par exemple) ;
@@ -55,14 +55,14 @@ Saisissez ici des précisions sur :
 
 La description est obligatoire.
 
-**Mots clés**
+### Mots clés
 Entrez ici les mots clés associés à votre réutilisation. Ils permettront aux autres utilisateurs de consulter des réutilisations ou des jeux de données du même type que les vôtres.
 
 Les mots clefs sont facultatifs
 
 Une fois votre réutilisation décrite, sauvegardez-la et passez à l’étape suivante en cliquant sur le bouton **Suivant**.
 
-### 3. Associer des jeux de données à la réutilisation
+## 3. Associer des jeux de données à la réutilisation
 
 Par défaut, votre réutilisation sera liée au jeu de données qui vous a servi de point de départ. Mais si votre réutilisation a exploité d’autres jeu de données, vous pouvez les associer à votre réutilisation à cette étape.
 
@@ -71,13 +71,13 @@ Pour lier d’autres jeux de données à votre réutilisation :
 1. Saisissez leurs titre dans le champ **Trouver votre jeu de données** ;
 2. Cliquez sur leur nom quand ils apparaissent à l’écran.
 
-### 4. Insérer une image
+## 4. Insérer une image
 
 Si votre réutilisation prend la forme d’une représentation graphique, vous pouvez en donner un aperçu aux autres utilisateurs au moyen d’une image ou d’une capture d’écran. Cette image figurera dans la partie **Réutilisations** de la page du jeu de donnée associé.
 
 Pour ajouter une image à votre réutilisation, cliquez sur le bouton **Choisissez un fichier de votre ordinateur** puis cliquez sur **Suivant**.
 
-### 5. Partager la réutilisation
+## 5. Partager la réutilisation
 
 Votre réutilisation est en ligne. Elle est visible sur la page du jeu de données qui lui a servi de base.
 


### PR DESCRIPTION
Le retour à la ligne ne fonctionne pas après du texte mis en gras.
```
**Gras**
Paragraphe
```
Donne 
```
**Gras** Paragraphe
```
 C’est laid. Cette _pull request_ remplace donc le gras par un titre de niveau 3, pour renvoyer à la ligne le paragraphe qui suit le titre.