### PR TITLE
Correction du lien "Editer cette page"

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -18,7 +18,7 @@ layout: default
           See: https://github.com/netlify/netlify-cms/issues/697
       {% endcomment %}
       <p class="edit text-center">
-          <a class="button" href="https://github.com/{{ site.github_repository }}/edit/master/{{ page.path }}">
+          <a class="button" href="https://github.com/{{ site.github_repository }}/edit/master/articles/{{ page.path }}">
               ✎ {{ site.i18n[lang].edit }}
           </a>
       </p>


### PR DESCRIPTION
Corrige le lien du bouton "Editer cette page" en prenant en compte le déplacement dans le sous-répertoire `articles`.