### PR TITLE
Modifie un article d’aide sur les réutilisations et index.md aussi

### DIFF
--- a/articles/_reutilisations-et-discussions/associer-une-reutilisation-a-un-jeu-de-donnees.md
+++ b/articles/_reutilisations-et-discussions/associer-une-reutilisation-a-un-jeu-de-donnees.md
@@ -9,11 +9,11 @@ Les données publiées sur data.gouv.fr peuvent être réutilisées selon les te
 
 ## Pourquoi référencer une réutilisation
 
-Référencer une réutilisation sur la page d’un jeu de données permet de :
+Référencer une réutilisation sur la page d’un jeu de données permet de :
 
 - donner de la visibilité à la réutilisation et au projet dans lequel elle s’inscrit ;
 - montrer à d’autres personnes comment le jeu de données peut être réutilisé ;
-- donner des idées et inspirer d'autres réutilisations potentielles ;
+- donner des idées et inspirer d’autres réutilisations potentielles ;
 - engager un dialogue avec le producteur du jeu de données.
 
 ## Comment référencer une réutilisation

--- a/articles/_reutilisations-et-discussions/associer-une-reutilisation-a-un-jeu-de-donnees.md
+++ b/articles/_reutilisations-et-discussions/associer-une-reutilisation-a-un-jeu-de-donnees.md
@@ -9,12 +9,12 @@ Les données publiées sur data.gouv.fr peuvent être réutilisées selon les te
 
 ## Pourquoi référencer une réutilisation
 
-Référencer une réutilisation sur la page d’un jeu de données ne prend que quelques secondes et permet de :
+Référencer une réutilisation sur la page d’un jeu de données permet de :
 
-- donner de la visibilité à la réutilisation ;
-- montrer à quoi le jeu de données peut servir ;
-- inspirer d’autres réutilisations potentielles ;
-- remercier le producteur des données réutilisées.
+- donner de la visibilité à la réutilisation et au projet dans lequel elle s’inscrit ;
+- montrer à d’autres personnes comment le jeu de données peut être réutilisé ;
+- donner des idées et inspirer d'autres réutilisations potentielles ;
+- engager un dialogue avec le producteur du jeu de données.
 
 ## Comment référencer une réutilisation
 

--- a/index.md
+++ b/index.md
@@ -36,7 +36,7 @@ L’ouverture des données d’intérêt public vise à encourager la réutilisa
 
 ## La communauté data.gouv.fr
 
-En consultant [le blog d’Etalab](https://www.etalab.gouv.fr) vous pourrez vous inscrire aux différents évènements (Hackathons, OpenData Camps, Conférences) organisés par Etalab.
+En consultant [le blog d’Etalab](https://www.etalab.gouv.fr) vous pourrez vous inscrire aux différents évènements (_hackathons_, _Open data camps_, conférences) organisés par Etalab.
 
 Nous vous invitons par ailleurs à suivre les comptes Twitter [@datagouvfr](https://twitter.com/datagouvfr) (actualité de la plateforme, annonce des nouveaux jeux de données) et [@etalab](https://twitter.com/etalab) (actualité de la mission Etalab et de l’ouverture des données publiques).
 

--- a/index.md
+++ b/index.md
@@ -3,50 +3,41 @@ layout: page
 summary: Les questions essentielles sur Data.gouv.fr
 
 buttons:
-  -
-    title: Citoyen
+  - title: Citoyen
     default: faq/citoyen
-  -
-    title: Producteur
+  - title: Producteur
     default: faq/producteur
-  -
-    title: Réutilisateur
+  - title: Réutilisateur
     default: faq/reutilisateur
-  -
-    title: Développeur
+  - title: Développeur
     default: faq/developpeur
-  -
-    title: Intégrateur
+  - title: Intégrateur
     default: faq/integrateur
-
 ---
 
-# Découvrir L'OpenData
+# À propos d’Etalab
 
-La mission Etalab, placée sous l’autorité du Premier ministre au sein du SGMAP, a pour mission d’accompagner l’ouverture des données publiques de l’État et des administrations. À ce titre, elle met en oeuvre et anime la plateforme ouverte des données publiques « data.gouv.fr » qui héberge les jeux de données et recense leurs réutilisations.
+Etalab accompagne l’ouverture des données publiques de l’État et des administrations. À ce titre, Etalab développe et anime la plateforme ouverte des données publiques [data.gouv.fr](https://www.data.gouv.fr), plateforme qui héberge les jeux de données et recense leurs réutilisations.
 
-## A quoi servent les données ouvertes ?
+## Découvrir l’open data
 
-L’ouverture des données (Open Data) vise à encourager la réutilisation des données au-delà de leur utilisation première par l’administration. En utilisant, directement ou via des applications, des données publiées sur la plateforme « data.gouv.fr », on peut par exemple :
+L’ouverture des données d’intérêt public vise à encourager la réutilisation des données au-delà de leur utilisation première par l’administration. En utilisant, directement ou via des applications, des données publiées sur la plateforme [data.gouv.fr](https://www.data.gouv.fr), on peut par exemple :
 
 - répondre à des questions ;
 - prendre des décisions, pour soi, sa commune, son association ou son entreprise ;
 - bénéficier de services utiles au quotidien : pour se déplacer, éviter le gaspillage alimentaire, connaître les services publics à proximité de son domicile ;
 - encourager la transparence démocratique des institutions et des élus, par exemple : connaître l’utilisation de la réserve parlementaire, les budgets de l’État et des collectivités, les titres de presse aidés par l’État.
 
-« data.gouv.fr » s’adresse :
+[data.gouv.fr](https://www.data.gouv.fr) s’adresse :
 
 - aux producteurs de données qui souhaitent les publier dans des formats ouverts et réutilisables ;
-- aux réutilisateurs qui peuvent référencer leurs réalisations : qu’il s’agisse d’un page, d’une visualisation de données ou d’une application ;
+- aux réutilisateurs qui peuvent référencer leurs réalisations ;
 - mais aussi à tout citoyen, association ou entreprise, qui peut ainsi découvrir et utiliser des données.
 
-## Comment faire partie de la communauté « data.gouv.fr » ?
+## La communauté data.gouv.fr
 
-En consultant [le blog de la mission Etalab][] vous pourrez vous inscrire aux différents évènements
-(Hackathons, OpenData Camps, Conférences) organisés par la mission Etalab.
+En consultant [le blog d’Etalab](https://www.etalab.gouv.fr) vous pourrez vous inscrire aux différents évènements (Hackathons, OpenData Camps, Conférences) organisés par Etalab.
 
 Nous vous invitons par ailleurs à suivre les comptes Twitter [@datagouvfr](https://twitter.com/datagouvfr) (actualité de la plateforme, annonce des nouveaux jeux de données) et [@etalab](https://twitter.com/etalab) (actualité de la mission Etalab et de l’ouverture des données publiques).
 
-L’équipe de cette plateforme est par ailleurs joignable par mail : [info@data.gouv.fr](mailto:info@data.gouv.fr).
-
-[le blog de la mission Etalab]: https://www.etalab.gouv.fr
+L’équipe qui travaille sur cette plateforme est par ailleurs joignable par e-mail : [info@data.gouv.fr](mailto:info@data.gouv.fr).


### PR DESCRIPTION
Cette _pull-request_ découle de #73. Elle modifie le contenu d’un article consacré aux réutilisations. Elle supprime aussi la mention du SGMAP (secrétariat général pour la modernisation de l’action publique) sur la page d’accueil de doc.data.gouv.fr, qui est créée à partir de `index.md`. 

Closes #73.