### PR TITLE
Ajout de la page certification

### DIFF
--- a/articles/_organisations/certification.md
+++ b/articles/_organisations/certification.md
@@ -1,0 +1,11 @@
+---
+title: Certifier une organisation
+---
+
+# Les services publics certifiés	
+
+Les organisations inscrites sur la plateforme « [data.gouv.fr](https://www.data.gouv.fr) » estimant assurer une mission de service public peuvent effectuer une demande en ligne pour être reconnues comme telles. Une organisation certifiée bénéficie d’un meilleur référencement.	
+
+## Comment certifier mon organisation ?
+
+Pour obtenir le badge « service public certifié » , inscrivez-vous sur le site en tant qu’individu, créez ou rejoignez votre organisation, puis effectuez la demande de certification en envoyant un mail avec votre mail officiel à l’adresse suivante : <certification@data.gouv.fr>. Une vérification par email ou courrier vous sera demandée. Vous pouvez néanmoins commencer à publier vos jeux de données avant d’obtenir le badge de certification.


### PR DESCRIPTION
Cette pull-request ajouter une page sur la certification des organisation qui a disparu dans ce commit: https://github.com/etalab/doc.data.gouv.fr/commit/0f1acbc97d82c0e010b9cc778fcbe38e90a99a96#diff-e0fb846fbf1506ae05379cbc80685798L24