### PR TITLE
Revert "Build directly master on GitHub Pages"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: circleci/ruby:2.3-stretch
+
+    working_directory: ~/doc.data.gouv.fr
+
     steps:
       - checkout
 
@@ -16,4 +19,51 @@ jobs:
 
       - run:
           name: Build website
-          command: bundle exec jekyll build --config _config.yml,_config_dev.yml --verbose
+          command: bundle exec jekyll build --verbose
+
+      - persist_to_workspace:
+          root: .
+          paths:
+          - _site
+
+  deploy:
+    docker:
+      - image: circleci/python:3.6
+
+    working_directory: ~/doc.data.gouv.fr
+
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "81:43:ff:eb:30:0a:85:4a:a1:cc:34:29:93:8d:6e:89"
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Expose user pip-installed binaries on path
+          command: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+      - run:
+          name: Deploy to github pages
+          command: |
+            pip install --user ghp-import
+            cp -R .circleci _site/
+            git config --global user.name CircleCI
+            git config --global user.email circleci@data.gouv.fr
+            ghp-import --cname=doc.data.gouv.fr -m "Deploy doc.data.gouv.fr" --push _site
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      # Build on any branch except github pages
+      - build:
+          filters:
+            branches:
+              ignore: gh-pages
+      # Deploy only on master
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-doc.data.gouv.fr

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Compiler et démarrer un serveur de documentation :
 git clone https://github.com/etalab/doc.data.gouv.fr
 cd doc.data.gouv.fr
 bundle install
-bundle exec jekyll serve --config _config.yml,_config_dev.yml --incremental
+bundle exec jekyll serve
 ```
 
 La documentation apparaîtra alors à l’adresse suivante : <a href="http://localhost:4000">http://localhost:4000</a>.

--- a/_config.yml
+++ b/_config.yml
@@ -68,7 +68,7 @@ defaults:
 sass:
   style: compressed
 
-remote_theme: etalab/template-jekyll
+theme: jekyll-theme-gouvfr
 
 plugins:
   - jekyll-redirect-from

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-gouvfr

--- a/deploy
+++ b/deploy
@@ -1,0 +1,10 @@
+
+#!/bin/bash
+
+echo "Start deploy"
+ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -tq root@staticweb-01.etalab.gouv.fr "bash -lc 'cd /var/www/doc.data.gouv.fr && git pull'"
+ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -tq root@staticweb-01.etalab.gouv.fr "bash -lc 'cd /var/www/doc.data.gouv.fr && bundle exec jekyll doctor'"
+ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -tq root@staticweb-01.etalab.gouv.fr "bash -lc 'cd /var/www/doc.data.gouv.fr && bundle exec jekyll build'"
+echo "Deployed Successfully!"
+
+exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   web:
     image: jekyll/jekyll:latest
-    command: jekyll serve --config _config.yml,_config_dev.yml --watch --force_polling -H 0.0.0.0 -P 4000
+    command: jekyll serve --watch --force_polling -H 0.0.0.0 -P 4000
     ports:
       - 4000:4000
       - 35729:35729


### PR DESCRIPTION
Reverts etalab/doc.data.gouv.fr#90

GitHub pages does not support custom plugins for now. Sad. https://stackoverflow.com/questions/53215356/jekyll-how-to-use-custom-plugins-with-github-pages