### PR TITLE
Update doc based to reflect frontendchanges

### DIFF
--- a/articles/_a-propos/que-publier-et-comment-le-publier.md
+++ b/articles/_a-propos/que-publier-et-comment-le-publier.md
@@ -26,7 +26,7 @@ Plus concrètement, un fichier Word qui contient des informations sur un projet 
 Si vous ne savez pas par où commencer, voici quelques idées de jeux de données à publier :
 
 - la liste des délibérations adoptées par une assemblée locale — [voir un exemple](https://www.data.gouv.fr/fr/datasets/5a8f387988ee381bb2a62a46) ;
-- la liste des subventions attribuées par une collectivité — [voir un exemple](https://www.data.gouv.fr/fr/datasets/5bd8fb5706e3e72ba58c0ec2) ;
+- la liste des subventions attribuées par une collectivité — [voir un exemple](https://www.data.gouv.fr/fr/datasets/610aa8d614984375f3cff7a0) ;
 - la liste des équipements publics gérés par une collectivité — [voir un exemple](https://www.data.gouv.fr/fr/datasets/595c271ca3a7296408d69b92) ;
 - la liste annuelle des prénoms des nouveaux-nés déclarés à l’état-civil — [voir un exemple](https://www.data.gouv.fr/fr/datasets/5407f862a3a7292ef9c20a61).
 
@@ -42,7 +42,7 @@ Pour chaque grand type de données, il existe un ou plusieurs format standard, c
 
 #### Données tabulaires
 
-Les données tabulaires (feuilles de calcul), gagnent à être publiées sous la forme de fichiers CSV (_comma-separated values_), reconnaissables à leur extension en `.csv`. Si le fichier que vous avez entre les mains est un fichier Excel, nous vous conseillons d’exporter vos données au format CSV. [Voir comment exporter des données au format CSV à partir d’Excel](https://www.ibm.com/support/knowledgecenter/fr/SSWU4L/WebLanding/imc_WebLanding/WebLanding_q_a_watson_assistant/Saving_a_CSV_file_with_UTF-8_encoding.html). Pourquoi du CSV et pas du XLS comme tout le monde ? Justement car tout le monde n’utilise pas Excel, qui est un logiciel payant.
+Les données tabulaires (feuilles de calcul), gagnent à être publiées sous la forme de fichiers CSV (_comma-separated values_), reconnaissables à leur extension en `.csv`. Si le fichier que vous avez entre les mains est un fichier Excel, nous vous conseillons d’exporter vos données au format CSV. [Voir comment exporter des données au format CSV à partir d’Excel](https://support.microsoft.com/en-us/office/import-or-export-text-txt-or-csv-files-5250ac4c-663c-47ce-937b-339e391393ba). Pourquoi du CSV et pas du XLS comme tout le monde ? Justement car tout le monde n’utilise pas Excel, qui est un logiciel payant.
 
 Quand vous créez votre fichier CSV, nous vous conseillons de :
 
@@ -86,7 +86,7 @@ Même raisonnement que pour les images et les vidéos : les fichiers Word, Power
 
 #### Autres types de données
 
-Pour approfondir la question des formats, nous vous conseillons de jeter un œil au [référentiel général d’interopérabilité](https://references.modernisation.gouv.fr/interoperabilite) (disponible au format PDF), qui référence les normes et les standards au sein des systèmes d’information de l’administration.
+Pour approfondir la question des formats, nous vous conseillons de jeter un œil au [référentiel général d’interopérabilité](https://www.numerique.gouv.fr/uploads/Referentiel_General_Interoperabilite_V2.pdf) (disponible au format PDF), qui référence les normes et les standards au sein des systèmes d’information de l’administration.
 
 ### Choisir une licence
 

--- a/articles/_a-propos/signaler-un-contenu.md
+++ b/articles/_a-propos/signaler-un-contenu.md
@@ -5,26 +5,12 @@ slug: signaler-un-contenu
 
 # Signaler un contenu
 
-Si vous possédez un compte utilisateur, vous pouvez signaler des jeux de données ou des réutilisations qui enfreignent les [conditions générales d’utilisation](https://www.data.gouv.fr/fr/terms/) de data.gouv.fr.
-
 Les signalements sont transmis à l’équipe technique de data.gouv.fr. Les responsables du site se réservent ensuite le droit de supprimer les données ou les réutilisations inappropriées.
 
-## Signaler un jeu de données
-
-Pour signaler un jeu de données qui vous semble inapproprié :
-
-1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur la page du jeu de données que vous souhaitez signaler ;
-3. Sous les ressources, cliquez sur le bouton rouge en forme de danger ;
-4. Cliquez sur **NOUVELLE ANOMALIE** ;
-5. Complétez les champs du formulaire puis cliquez sur **SOUMETTRE** pour avertir les modérateurs de la plateforme.
-
-## Signaler une réutilisation
-
-Pour signaler une réutilisation qui vous semble inappropriée :
-
-1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur la page de la réutilisation que vous souhaitez signaler ;
-3. Sous l’image de la réutilisation, cliquez sur le bouton rouge en forme de danger ;
-4. Cliquez sur **NOUVELLE ANOMALIE** ;
-5. Complétez les champs du formulaire puis cliquez sur **SOUMETTRE** pour avertir les modérateurs de la plateforme.
+Afin de signaler un contenu qui vous semble inapproprié :
+1. Rendez vous sur [https://support.data.gouv.fr/]() ;
+2. Sélectionnez le champ adéquat dans la partie **Qui êtes vous ?** ;
+3. Sélectionnez `Autre` dans la partie **Comment pouvons-nous vous aider ?** ;
+4. Complétez votre email dans **Contactez-nous** ;
+5. Renseignez **L’objet de votre question** en indiquant qu’il s’agit d’un *signalement* ;
+6. Remplissez le champ **Votre question** en ajoutant un lien vers le jeu de données ou la réutilisation qui vous semble inappropriés.

--- a/articles/_api/telecharger-un-catalogue-de-donnees.md
+++ b/articles/_api/telecharger-un-catalogue-de-donnees.md
@@ -19,14 +19,16 @@ Pour télécharger un catalogue, cliquez sur l’URL associée aux données qui 
 
 Le catalogue des jeux de données est aussi publié dans plusieurs formats, pour en faciliter la consultation.
 
-Voici la liste des formats proposés et les URL (liens) correspondantes :
+Voici la liste des formats proposés avec les MIME type à utiliser ainsi que les URL (liens) correspondantes :
 
-- JSON-LD : <https://www.data.gouv.fr/catalog.jsonld> ;
-- Turtle : <https://www.data.gouv.fr/catalog.ttl> ;
-- N-Triples : <https://www.data.gouv.fr/catalog.nt> ;
-- XML-RDF : <https://www.data.gouv.fr/catalog.xml> ;
-- N3 : <https://www.data.gouv.fr/catalog.n3> ;
-- Trig : <https://www.data.gouv.fr/catalog.trig>.
+| Format    | URL                                       | MIME type                                 |
+|-----------|-------------------------------------------|-------------------------------------------|
+| RDF/XML   | <https://www.data.gouv.fr/catalog.xml>    | **application/rdf+xml**, application/xml  |
+| Turtle    | <https://www.data.gouv.fr/catalog.ttl>    | **text/turle**, application/x-turtle      |
+| N3        | <https://www.data.gouv.fr/catalog.n3>     | **text/n3**                               |
+| JSON-LD   | <https://www.data.gouv.fr/catalog.jsonld> | **application/ld+json**, application/json |
+| N-Triples | <https://www.data.gouv.fr/catalog.nt>     | **application/n-triples**                 |
+| TriG      | <https://www.data.gouv.fr/catalog.trig>   | **application/trig**                      |
 
 ## Statistiques de fréquentation de data.gouv.fr
 

--- a/articles/_gestion-du-compte/supprimer-un-compte.md
+++ b/articles/_gestion-du-compte/supprimer-un-compte.md
@@ -8,8 +8,8 @@ slug: supprimer-un-compte
 Pour clôturer votre compte :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
-3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Moi**, dans la colonne de gauche ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
+3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Profil**, dans la colonne de gauche ;
 4. Cliquez sur la flèche située à côté du bouton **Éditer**, en haut à droite de votre écran, puis sur **Supprimer le profil** dans le menu déroulant qui apparaît alors ;
 5. Confirmez la suppression de votre compte en cliquant sur le bouton **Confirmer**, qui figure dans la boîte de dialogue rouge.
 

--- a/articles/_gestion-du-compte/voir-ou-modifier-votre-compte.md
+++ b/articles/_gestion-du-compte/voir-ou-modifier-votre-compte.md
@@ -5,7 +5,7 @@ slug: voir-ou-modifier-votre-compte
 
 # Voir ou modifier votre compte
 
-Votre page de profil contient des informations au sujet de vos contributions, vos jeux de données, et vos abonnements. Cette page est visible par tout le monde, elle ne nécessite pas de compte utilisateur pour être consultée.
+> ⚠️ Attention : La page de profil utilisateur visible par tout le monde est en cours de développement suite à la [refonte graphique](https://www.data.gouv.fr/fr/posts/nouvelle-vie-nouvelle-peau-pour-data-gouv-fr/).
 
 ## À propos de votre page de profil
 
@@ -24,19 +24,12 @@ Votre profil contient les informations suivantes :
 
 L’adresse e-mail associée à votre compte n’est pas affichée sur votre profil public.
 
-## Voir votre profil
-
-Pour voir votre profil :
-
-1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Cliquez sur votre nom et prénom, en haut à droite de votre écran, puis sur **Mon profil**.
-
 ## Modifier votre profil
 
 Pour modifier les informations associées à un compte existant :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Moi**, dans la colonne de gauche.
 
 Depuis la page **Moi**, vous pouvez :

--- a/articles/_jeux-de-donnees/demander-a-datagouvfr-de-moisonner-votre-site.md
+++ b/articles/_jeux-de-donnees/demander-a-datagouvfr-de-moisonner-votre-site.md
@@ -28,7 +28,8 @@ Les moissonneurs de data.gouv.fr ne fonctionnent qu’avec certains formats de m
 - [CKAN]({{ site.baseurl }}{% link _moissonnage/ckan.md %}) ;
 - [DCAT]({{ site.baseurl }}{% link _moissonnage/dcat.md %}).
 
-Il existe [un cas particulier pour les données issues d'Inspire]({{ site.baseurl }}{% link _moissonnage/intro.md %}#moissonnage-vs-geodatagouvfr), leur moissonnage se fait depuis [geo.data.gouv.fr](https://geo.data.gouv.fr).
+Il existe [un cas particulier pour les données issues d’Inspire]({{ site.baseurl }}{% link _moissonnage/intro.md %}#moissonnage-vs-geodatagouvfr), leur moissonnage se fait depuis [geo.data.gouv.fr](https://geo.data.gouv.fr).
+> ⚠️ Attention : [geo.data.gouv.fr](https://geo.data.gouv.fr) n’est plus activement maintenu. Plus d’informations à propos [de l’extinction de geo.data.gouv.fr sont disponibles ici](https://www.data.gouv.fr/fr/posts/extinction-de-geo-data-gouv-fr/).
 
 ## Créer un moissonneur
 
@@ -37,7 +38,7 @@ La création d’un moissonneur sur data.gouv.fr nécessite la création d’un 
 Pour créer un nouveau moissonneur :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Cliquez sur l’icône en forme de plus (`+`) qui se trouve à gauche de votre avatar ;
 4. Cliquez sur **Un moissonneur**.
 
@@ -86,7 +87,7 @@ L’URL est obligatoire.
 
 Choisissez ici le format des métadonnées associées aux jeux de données publiés sur votre plateforme. Ce format permet au moissonneur de savoir comment lire et interpréter vos métadonnées, pour bien les retranscrire sur data.gouv.fr.
 
-Certaines implémentations permettent d'ajouter des filtres, dans le but d’inclure ou d’exclure certains jeux de données du moissonnage. (Consultez [la section dédié de la documentation de moissonnage]({{ site.baseurl }}{% link _moissonnage/intro.md %}#filtrage) ainsi que les filtres [spécifiques de votre implémentations](({{ site.baseurl }}{% link _moissonnage/intro.md %}#moissonneurs-disponibles)))
+Certaines implémentations permettent d'ajouter des filtres, dans le but d’inclure ou d’exclure certains jeux de données du moissonnage. (Consultez [la section dédié de la documentation de moissonnage]({{ site.baseurl }}{% link _moissonnage/intro.md %}#filtrage) ainsi que les filtres [spécifiques de votre implémentations]({{ site.baseurl }}{% link _moissonnage/intro.md %}#moissonneurs-disponibles))
 
 Le type d’implémentation est obligatoire.
 

--- a/articles/_jeux-de-donnees/difference-jeu-de-donnees-et-ressource.md
+++ b/articles/_jeux-de-donnees/difference-jeu-de-donnees-et-ressource.md
@@ -30,7 +30,7 @@ Un jeu de données est référencé par au moins deux liens :
 1. Lien avec un _slug_ (version « machine » du titre du jeu de données) : [https://www.data.gouv.fr/fr/datasets/resultats-des-elections-europeennes-2019/](https://www.data.gouv.fr/fr/datasets/resultats-des-elections-europeennes-2019/) ;
 2. Lien avec un identifiant permanent : [https://www.data.gouv.fr/datasets/5ceba293634f411427c7d613](https://www.data.gouv.fr/datasets/5ceba293634f411427c7d613).
 
-Le lien avec identifiant permanent ne change jamais pendant toute la durée de vie d'un même jeu de données. C'est la manière la plus fiable et la plus pérenne de partager le lien d'un jeu de données. Ce lien est accessible depuis le bouton « Détails » dans l'encart « Informations » sur la page d'un jeu de données, à la ligne « ID ».
+Le lien avec identifiant permanent ne change jamais pendant toute la durée de vie d'un même jeu de données. C'est la manière la plus fiable et la plus pérenne de partager le lien d'un jeu de données. L'identifiant permanent est accessible depuis l'onglet « Extras » dans l'encart bleu en haut de la page d'un jeu de données, à la ligne « ID ».
 
 Le lien avec _slug_ change à chaque fois que le titre du jeu de données change. Toutefois, une redirection depuis l'ancien lien vers le nouveau est automatiquement créée quand le titre change.
 
@@ -50,13 +50,8 @@ Une ressource comporte :
 
 ### Liens (URL)
 
-Une ressource est référencée par deux types de liens :
+Une ressource est référencée par deux types de liens. Il s'agit de liens vers le fichier (ou l'API, la page...) en lui-même, i.e. le contenu de la ressource :
+1. un lien direct qui peut changer quand une ressource est mise à jour : [https://static.data.gouv.fr/resources/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques/20190805-140412/bornes-irve-20190805.csv](https://static.data.gouv.fr/resources/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques/20190805-140412/bornes-irve-20190805.csv) ;
+2. un lien stable (URL stable) qui ne change pas pendant tout le cycle de vie d'une même ressource : [https://www.data.gouv.fr/fr/datasets/r/50625621-18bd-43cb-8fde-6b8c24bdabb3](https://www.data.gouv.fr/fr/datasets/r/50625621-18bd-43cb-8fde-6b8c24bdabb3). Ce lien donne toujours accès à la dernière version du contenu de la ressource.
 
-1. Un lien vers la page sur data.gouv.fr décrivant la ressource : [https://www.data.gouv.fr/fr/datasets/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques/#resource-50625621-18bd-43cb-8fde-6b8c24bdabb3](https://www.data.gouv.fr/fr/datasets/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques/#resource-50625621-18bd-43cb-8fde-6b8c24bdabb3) ;
-2. Deux liens vers le fichier (ou l'API, la page...) en lui-même, i.e. le contenu de la ressource :
-    - un lien direct qui peut changer quand une ressource est mise à jour : [https://static.data.gouv.fr/resources/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques/20190805-140412/bornes-irve-20190805.csv](https://static.data.gouv.fr/resources/fichier-consolide-des-bornes-de-recharge-pour-vehicules-electriques/20190805-140412/bornes-irve-20190805.csv) ;
-    - un lien stable (URL stable) qui ne change pas pendant tout le cycle de vie d'une même ressource : [https://www.data.gouv.fr/fr/datasets/r/50625621-18bd-43cb-8fde-6b8c24bdabb3](https://www.data.gouv.fr/fr/datasets/r/50625621-18bd-43cb-8fde-6b8c24bdabb3). Ce lien donne toujours accès à la dernière version du contenu de la ressource.
-
-Ces différents liens sont accessibles après avoir cliqué sur l'encart d'une ressource depuis la page d'un jeu de données :
-- le lien vers la page sur data.gouv.fr est présent dans la barre d'adresse du navigateur ;
-- les autres liens sont presentés dans la fenêtre d'informations au niveau des lignes « URL » et « URL stable ».
+Ces différents liens sont accessibles après avoir déroulé l'encart d'une ressource depuis la page d'un jeu de données. Les liens sont presentés dans les informations au niveau des lignes « URL » et « URL stable ».

--- a/articles/_jeux-de-donnees/faire-une-recherche.md
+++ b/articles/_jeux-de-donnees/faire-une-recherche.md
@@ -7,7 +7,7 @@ slug: faire-une-recherche
 
 Utilisez notre barre de recherche pour trouver ce que vous cherchez sur data.gouv.fr parmi les jeux de données, les réutilisations de données, et les organisations.
 
-Après avoir fait une recherche sur data.gouv.fr, vous pouvez trier les résultats, ou les restreindre davantage en activant les filtres de la barre latérale.
+Après avoir fait une recherche sur data.gouv.fr, vous pouvez trier les résultats, ou les restreindre davantage en utilisant les différents filtres de recherche.
 
 ## Ce que vous pouvez chercher
 
@@ -15,14 +15,16 @@ Vous pouvez chercher les choses suivantes au sein du catalogue de data.gouv.fr :
 
 - jeux de données ;
 - réutilisations ;
-- organisations ;
-- territoires (régions, départements, communes).
+- organisations.
 
 Vous ne pouvez pas chercher les choses suivantes :
 
 - utilisateurs individuels ;
 - ressources ;
-- discussions.
+- discussions ;
+- territoires.
+
+> ⚠️ Attention : Les pages de recherche sont en développement suite à la [refonte graphique](https://www.data.gouv.fr/fr/posts/nouvelle-vie-nouvelle-peau-pour-data-gouv-fr/) et ne correspondent pas à la documentation ci-dessous.
 
 ## Utiliser la page de recherche
 

--- a/articles/_jeux-de-donnees/integrer-des-donnees.md
+++ b/articles/_jeux-de-donnees/integrer-des-donnees.md
@@ -9,12 +9,12 @@ Les jeux de données publiés sur data.gouv.fr sont publics, ils peuvent donc ê
 
 Pour intégrer un jeu de données sur une autre page web ou sur un blog :
 
-1. Sur la page du jeu de données à intégrer, cliquez sur l’icône `</>` ;
-2. Du code (HTML) s’affiche alors dans une petite fenêtre, copiez-le ;
+1. Sur la page du jeu de données à intégrer, descendez en-dessous des ressources jusqu’à la section **Embed** ;
+2. Du code (HTML) s’affiche alors dans une petite fenêtre, copiez-le (vous pouvez utiliser) le bouton à droite pour ce faire ;
 3. Collez le code dans votre propre fichier, là où vous souhaitez afficher les données.
 
 Plusieurs jeux de données peuvent être intégrés sur une même page web. Vous pouvez aussi contrôler l’apparence du jeu de données intégré en modifiant la classe CSS `dataset-card`.
 
 ## Intégrer un catalogue de données sur un site web
 
-Pour aller plus loin qu’une simple intégration de jeux de données, une [bibliothèque Javascript](https://github.com/datakode/metaclic) (Metaclic) est disponible, qui permet de créer et personnaliser un véritable catalogue de données. [Voir un exemple de catalogue](https://datakode.github.io/metaclic/exemples/exemple_simple.html) ou [lire la documentation de Metaclic](https://github.com/datakode/metaclic/wiki).
+Pour aller plus loin qu’une simple intégration de jeux de données, une [bibliothèque Javascript](https://github.com/datakode/metaclic) (Metaclic) est disponible, qui permet de créer et personnaliser un véritable catalogue de données. [Lire la documentation de Metaclic](https://github.com/datakode/metaclic/wiki).

--- a/articles/_jeux-de-donnees/mettre-a-jour-un-jeu-de-donnees-ou-une-ressource.md
+++ b/articles/_jeux-de-donnees/mettre-a-jour-un-jeu-de-donnees-ou-une-ressource.md
@@ -16,8 +16,8 @@ Si vous souhaitez mettre à jour des données, mieux vaut modifier les ressource
 Pour mettre à jour un jeu de données publié avec votre propre compte, à titre personnel :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
-3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Moi**, dans la colonne de gauche ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
+3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Profil**, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** située en milieu de page ;
 5. Cliquez sur le jeu de données que vous souhaitez modifier ;
 6. Cliquez sur le bouton **Éditer**, en haut à droite de votre écran ;
@@ -29,7 +29,7 @@ Pour mettre à jour un jeu de données publié avec votre propre compte, à titr
 Pour supprimer un jeu de données publié au nom d’une organisation à laquelle vous appartenez :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur la page de suivi de votre organisation, en cliquant sur le nom de votre organisation, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** située en milieu de page ;
 5. Cliquez sur le jeu de données que vous souhaitez supprimer ;
@@ -46,8 +46,8 @@ La modification d’une ressource existante permet d’en mettre à jour le cont
 Pour modifier une ressource publiée avec votre propre compte, à titre personnel :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
-3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Moi**, dans la colonne de gauche ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
+3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Profil**, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** située en milieu de page ;
 5. Cliquez sur le jeu de données qui contient la ressource à modifier ;
 6. Naviguez jusqu’à la section **Ressources** située en milieu de page ;
@@ -61,7 +61,7 @@ Pour modifier une ressource publiée avec votre propre compte, à titre personne
 Pour modifier une ressource publiée au nom d’une organisation à laquelle vous appartenez :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur la page de suivi de votre organisation, en cliquant sur le nom de votre organisation, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** située en milieu de page ;
 5. Cliquez sur le jeu de données qui contient la ressource à modifier ;

--- a/articles/_jeux-de-donnees/publier-un-jeu-de-donnees.md
+++ b/articles/_jeux-de-donnees/publier-un-jeu-de-donnees.md
@@ -11,7 +11,7 @@ La publication d’un jeu de données sur data.gouv.fr nécessite la création d
 Pour mettre en ligne un nouveau jeu de données :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [la page de création d’un jeu de données](https://www.data.gouv.fr/fr/admin/dataset/new/), en cliquant sur le bouton **CONTRIBUEZ !** qui se trouve au centre de votre écran.
+2. Rendez-vous sur [la page de création d’un jeu de données](https://www.data.gouv.fr/fr/admin/dataset/new/), en cliquant sur le bouton **Publiez un jeu de données** dans le bandeau **Participez** en bas de page.
 
 À partir de là, la publication se déroule en 4 étapes.
 
@@ -152,6 +152,19 @@ Par défaut, il s’agit de la date à laquelle vous importez votre fichier sur 
 Si vous référencez un fichier hébergé ailleurs que sur data.gouv.fr, il s’agit de la date à laquelle votre fichier a été mis en ligne.
 
 La date de publication est facultative.
+
+### Schéma
+
+Les schémas de données permettent de décrire des modèles de données : quels sont les différents champs, comment sont représentées les données, quelles sont les valeurs possibles etc.
+Pour en savoir plus sur les schémas, consultez [schema.data.gouv.fr](https://schema.data.gouv.fr/).
+
+Il s'agit pour ce champ de l’identifiant du schéma auquel la ressource adhère, le cas échéant.
+
+Deux cas possibles :
+- si vous importez un fichier, une validation sera effectuée sur la ressource pour s’assurer qu’elle correspond bien au fichier indiqué.
+- si vous référencez un fichier hébergé ailleurs, sur un autre site, aucune validation de correspondance au schéma n’est effectuée.
+
+Le schéma est facultatif.
 
 ### URL
 

--- a/articles/_jeux-de-donnees/supprimer-un-jeu-de-donnees.md
+++ b/articles/_jeux-de-donnees/supprimer-un-jeu-de-donnees.md
@@ -18,8 +18,8 @@ La suppression d’un jeu de données dans son intégralité entraine la suppres
 Pour supprimer un jeu de données publié avec votre propre compte, à titre personnel :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
-3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Moi**, dans la colonne de gauche ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
+3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Profil**, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** située en milieu de page ;
 5. Cliquez sur le jeu de données que vous souhaitez supprimer ;
 6. Cliquez sur la flèche située à côté du bouton **Éditer**, en haut à droite de votre écran, puis sur **Supprimer** dans le menu déroulant qui apparaît alors ;
@@ -30,7 +30,7 @@ Pour supprimer un jeu de données publié avec votre propre compte, à titre per
 Pour supprimer un jeu de données publié au nom d’une organisation à laquelle vous appartenez :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur la page de suivi de votre organisation, en cliquant sur le nom de votre organisation, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** située en milieu de page ;
 5. Cliquez sur le jeu de données que vous souhaitez supprimer ;
@@ -46,8 +46,8 @@ La suppression d’une ressources n’entraîne pas la suppression du jeu de don
 Pour supprimer une ressource publiée avec votre propre compte, à titre personnel :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
-3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Moi**, dans la colonne de gauche ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
+3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Profil**, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** située en milieu de page ;
 5. Cliquez sur le jeu de données qui contient la ressource à supprimer ;
 6. Naviguez jusqu’à la section **Ressources** située en milieu de page ;
@@ -60,7 +60,7 @@ Pour supprimer une ressource publiée avec votre propre compte, à titre personn
 Pour supprimer une ressource publiée au nom d’une organisation à laquelle vous appartenez :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur la page de suivi de votre organisation, en cliquant sur le nom de votre organisation, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** située en milieu de page ;
 5. Cliquez sur le jeu de données qui contient la ressource à supprimer ;

--- a/articles/_jeux-de-donnees/telecharger-une-ressource.md
+++ b/articles/_jeux-de-donnees/telecharger-une-ressource.md
@@ -5,12 +5,12 @@ slug: telecharger-une-ressource
 
 # Télécharger une ressource
 
-Quand vous consultez un jeu de données sur data.gouv.fr, les ressources qu’ils contient sont hébergées sur un serveur. Pour récupérer les ressources sur votre propre machine, vous devez les télécharger. Il n’est pas nécessaire de posséder un compte sur data.gouv.fr pour télécharger des données qui y sont répertoriées.
+Quand vous consultez un jeu de données sur data.gouv.fr, les ressources qu’il contient sont hébergées sur un serveur. Pour récupérer les ressources sur votre propre machine, vous devez les télécharger. Il n’est pas nécessaire de posséder un compte sur data.gouv.fr pour télécharger des données qui y sont répertoriées.
 
 Pour télécharger une ressource :
 
 1. Naviguez jusqu’au jeu de données qui contient la ressource à télécharger ;
-2. Repérez la ressource à obtenir et cliquez sur le bouton **Télécharger** qui s’y rapporte ;
+2. Repérez la ressource à obtenir et cliquez sur le bouton vert à droite avec l’icône de **Téléchargement** qui s’y rapporte ;
 3. Votre téléchargement commence.
 
 Dans certains cas, vous pouvez prévisualiser un fichier avant de le télécharger en cliquant sur le bouton **Prévisualiser** qui se trouve à côté du bouton **Télécharger**. Cette fonctionnalité n’est pas disponible pour tous les fichiers.

--- a/articles/_jeux-de-donnees/transferer-un-jeu-de-donnees.md
+++ b/articles/_jeux-de-donnees/transferer-un-jeu-de-donnees.md
@@ -12,8 +12,8 @@ Un jeu de données publié au nom d’un individu ou d’une organisation peut �
 Pour transférer un jeu de données publié avec votre propre compte, à titre personnel :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
-3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Moi**, dans la colonne de gauche ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
+3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Profil**, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** située en milieu de page ;
 5. Cliquez sur le jeu de données que vous souhaitez transférer ;
 6. Cliquez sur la flèche située à côté du bouton **Éditer**, en haut à droite de votre écran, puis sur **Transférer** dans le menu déroulant qui apparaît alors ;
@@ -27,7 +27,7 @@ Pour transférer un jeu de données publié avec votre propre compte, à titre p
 Pour transférer un jeu de données publié pour le compte d’une organisation :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur la page de suivi de votre organisation, en cliquant sur le nom de votre organisation, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** située en milieu de page ;
 5. Cliquez sur le jeu de données que vous souhaitez transférer ;
@@ -42,6 +42,6 @@ Pour transférer un jeu de données publié pour le compte d’une organisation 
 Pour accepter une demande de transfert vers votre compte :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Cliquez sur l’enveloppe située en haut à droite de votre écran, puis sur le message dont le titre est **Demande de transfert en attente** ;
 4. Vérifiez que le jeu de données que vous êtes sur le point d’accepter est le bon puis cliquez sur **Accepter** pour confirmer le transfert.

--- a/articles/_moissonnage/intro.md
+++ b/articles/_moissonnage/intro.md
@@ -29,6 +29,8 @@ La publication par l'API vous donne un contrôle total sur le contenu de chaque 
 
 ### Moissonnage vs. geo.data.gouv.fr
 
+> /!\ Attention: [geo.data.gouv.fr](https://geo.data.gouv.fr) n’est plus activement maintenu. Plus d’informations à propos [de l’extinction de geo.data.gouv.fr sont disponibles ici](https://www.data.gouv.fr/fr/posts/extinction-de-geo-data-gouv-fr/).
+
 En plus du moissonnage et de l'utilisation de l'API, il existe un autre moyen automatisé de récupération des métadonnées sur data.gouv.fr : [geo.data.gouv.fr](https://geo.data.gouv.fr), anciennement inspire.data.gouv.fr.
 Ce site pivot permet de récupérer les métadonnées de jeux de données exposés selon [la directive européenne Inspire](https://inspire.ec.europa.eu) (obligation légale de publication des metadonnées geographiques selon le modèle de données **ISO 19115**, au format de données **ISO 19139**).
 

--- a/articles/_organisations/ajouter-un-utilisateur-a-une-organisation.md
+++ b/articles/_organisations/ajouter-un-utilisateur-a-une-organisation.md
@@ -12,7 +12,7 @@ Vous pouvez ajouter n’importe quel utilisateur de data.gouv.fr à une organisa
 Pour ajouter un nouvel utilisateur à une organisation dont vous êtes administrateur :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur la page de suivi de l’organisation à laquelle vous souhaitez ajouter un membre, en cliquant sur le nom de votre organisation, dans la colonne de gauche ;
 4. Dans le bloc **Membres**, sur la droite de votre écran, cliquez sur le bouton **Ajouter** ;
 5. Saisissez le prénom et le nom de l’utilisateur à ajouter, puis sélectionnez-le quand vous le voyez apparaître dans la liste ;

--- a/articles/_organisations/creer-une-organisation.md
+++ b/articles/_organisations/creer-une-organisation.md
@@ -29,7 +29,7 @@ Nous vous conseillons de créer une organisation si vous souhaitez :
 Pour créer une organisation :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [la page de création d’une organisation](https://www.data.gouv.fr/fr/admin/organization/new/), en cliquant sur le bouton **CONTRIBUEZ !** qui se trouve au centre de votre écran et en cliquant sur **Créez ou trouvez votre organisation**.
+2. Rendez-vous sur [la page de création d’une organisation](https://www.data.gouv.fr/fr/admin/organization/new/), en cliquant sur le lien **Créez ou trouvez votre organisation** dans le bandeau **Participez** en bas de page.
 
 ### 1. Éviter les doublons
 

--- a/articles/_organisations/demander-a-rejoindre-une-organisation.md
+++ b/articles/_organisations/demander-a-rejoindre-une-organisation.md
@@ -9,6 +9,8 @@ N’importe quel utilisateur peut demander à rejoindre n’importe quelle organ
 
 ## Comment demander à rejoindre une organisation
 
+> ⚠️ Attention : La page organisation est en cours de développement suite à la [refonte graphique](https://www.data.gouv.fr/fr/posts/nouvelle-vie-nouvelle-peau-pour-data-gouv-fr/) et ne correspond pas à la documentation ci-dessous.
+
 Pour faire une demande :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
@@ -22,7 +24,7 @@ Pour faire une demande :
 Pour accepter un nouvel utilisateur dans votre organisation suite à une demande de ce dernier :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Cliquez sur l’icône en forme d’enveloppe qui se trouve en haut à droite de votre écran ;
 4. Cliquez sur la ligne _Demande d’adhésion en attente_ ;
 5. Dans le bloc **Membres**, cliquez sur le bouton vert en forme de `v` pour accepter la demande — ou sur le bouton rouge (`x`) pour la rejeter

--- a/articles/_organisations/retirer-un-utilisateur-d-une-organisation.md
+++ b/articles/_organisations/retirer-un-utilisateur-d-une-organisation.md
@@ -14,7 +14,7 @@ Seuls les administrateurs d’une organisation peuvent retirer des membres de le
 Pour retirer un membre d’une organisation dont vous êtes administrateur :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur la page de suivi de l’organisation à laquelle vous souhaitez retirer un membre, en cliquant sur le nom de votre organisation, dans la colonne de gauche ;
 4. Dans le bloc **Membres**, sur la droite de votre écran, cliquez sur le nom du membre que vous souhaitez retirer ;
 5. Dans la fenêtre qui s’ouvre alors, cliquez sur **Supprimer** ;

--- a/articles/_organisations/supprimer-une-organisation.md
+++ b/articles/_organisations/supprimer-une-organisation.md
@@ -18,7 +18,7 @@ L’ordre des suppressions a son importance. Si vous souhaitez _aussi_ supprimer
 Pour supprimer une organisation dont vous êtes administrateur :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur la page de suivi de l’organisation à supprimer, en cliquant sur le nom de votre organisation, dans la colonne de gauche ;
 4. Cliquez sur la flèche située à côté du bouton **Éditer**, en haut à droite de votre écran, puis sur **Supprimer** dans le menu déroulant qui apparaît alors ;
 5. Validez la suppression de l’organisation en cliquant sur le bouton **Confirmer** dans la fenêtre rouge qui s’ouvre alors en superposition.

--- a/articles/_reutilisations-et-discussions/moderer-une-discussion.md
+++ b/articles/_reutilisations-et-discussions/moderer-une-discussion.md
@@ -26,7 +26,7 @@ Pour récupérer le lien d’une discussion :
 
 Pour récupérer le lien d’un commentaire spécifique :
 
-1. Cliquez sur l’icône en forme de 8 penché qui se situe à côté de la date à laquelle le commentaire en question a été publié ;
+1. Cliquez sur l’icône en forme de 8 penché qui se situe au bout de la ligne où se trouve le commentaire en question ;
 2. Copiez l’URL qui s’affiche alors dans votre navigateur, elle doit maintenant se terminer par `#discussion-XXX`.
 
 ## Ajouter un commentaire
@@ -34,8 +34,8 @@ Pour récupérer le lien d’un commentaire spécifique :
 Pour ajouter un commentaire dans une discussion existante :
 
 1. Rendez-vous au bas de la discussion ;
-2. Cliquez sur **AJOUTER UN COMMENTAIRE** ;
-3. Dans le champ **Commenter** qui s’ouvre alors, entrez votre message puis cliquez sur le bouton **ENVOYER VOTRE COMMENTAIRE** pour le publier ;
+2. Cliquez sur **Répondre** ;
+3. Dans le champ **Répondre à la discussion** qui s’ouvre alors, entrez votre message puis cliquez sur le bouton **Soumettre** pour le publier ;
 4. L’utilisateur ou l’organisation à l’origine de la discussion recevra alors une notification l’invitant à vous répondre.
 
 ## Fermer une discussion
@@ -47,7 +47,7 @@ Une discussion close ne peut plus faire l’objet de nouveaux commentaires, mais
 Pour fermer une discussion :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit) (ou sur celle de votre organisation), en cliquant sur **Moi** (ou sur le nom de votre organisation), dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Jeux de données** (ou **Réutilisations**) située en milieu de page ;
 5. Cliquez sur le jeu de données (ou la réutilisation) auquel est associé la discussion à fermer ;

--- a/articles/_reutilisations-et-discussions/modifier-ou-supprimer-une-reutilisation.md
+++ b/articles/_reutilisations-et-discussions/modifier-ou-supprimer-une-reutilisation.md
@@ -16,8 +16,8 @@ Si vous souhaitez changer le titre, la description, l’image, ou encore le lien
 Pour modifier une réutilisation publiée avec votre propre compte, à titre personnel :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
-3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Moi**, dans la colonne de gauche ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
+3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Profil**, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Réutilisations** située en milieu de page ;
 5. Cliquez sur la réutilisation que vous souhaitez modifier ;
 6. Cliquez sur le bouton **Éditer**, en haut à droite de votre écran ;
@@ -29,7 +29,7 @@ Pour modifier une réutilisation publiée avec votre propre compte, à titre per
 Pour modifier une réutilisation publiée au nom d’une organisation à laquelle vous appartenez :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur la page de suivi de votre organisation, en cliquant sur le nom de votre organisation, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Réutilisations** située en milieu de page ;
 5. Cliquez sur la réutilisation que vous souhaitez modifier ;
@@ -46,8 +46,8 @@ Si votre réutilisation n’est plus en ligne ou plus d’actualité, vous avez 
 Pour supprimer une réutilisation publiée avec votre propre compte, à titre personnel :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
-3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Moi**, dans la colonne de gauche ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
+3. Allez sur [la page de suivi de votre compte](https://www.data.gouv.fr/fr/admin/me/edit), en cliquant sur **Profil**, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Réutilisations** située en milieu de page ;
 5. Cliquez sur la réutilisation que vous souhaitez supprimer ;
 6. Cliquez sur la flèche située à côté du bouton **Éditer**, en haut à droite de votre écran, puis sur **Supprimer** dans le menu déroulant qui apparaît alors ;
@@ -58,7 +58,7 @@ Pour supprimer une réutilisation publiée avec votre propre compte, à titre pe
 Pour supprimer une réutilisation publiée au nom d’une organisation à laquelle vous appartenez :
 
 1. [Connectez-vous à votre compte](https://www.data.gouv.fr/fr/login) ;
-2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur votre nom et prénom, en haut à droite de votre écran, puis sur **Administration** ;
+2. Rendez-vous sur [votre tableau de bord](https://www.data.gouv.fr/fr/admin/), en cliquant sur **Administration** en haut à droite de votre écran ;
 3. Allez sur la page de suivi de votre organisation, en cliquant sur le nom de votre organisation, dans la colonne de gauche ;
 4. Naviguez jusqu’à la section **Réutilisations** située en milieu de page ;
 5. Cliquez sur la réutilisation que vous souhaitez supprimer ;

--- a/articles/_reutilisations-et-discussions/ouvrir-une-discussion.md
+++ b/articles/_reutilisations-et-discussions/ouvrir-une-discussion.md
@@ -24,5 +24,5 @@ Pour créer une nouvelle discussion :
 3. Cliquez sur la zone intitulée **Démarrer une nouvelle discussion** — un formulaire s’ouvre alors ;
 4. Dans le champ **Titre** du formulaire, saisissez l’objet de votre message, par exemple : _Question sur les noms des colonnes du fichier CSV_ ;
 5. Dans le champ **Commenter**, saisissez votre message ;
-6. Pour publier votre message sur la page, cliquez sur le bouton bleu **DÉMARRER UNE DISCUSSION** ;
+6. Pour publier votre message sur la page, cliquez sur le bouton bleu **Soumettre** ;
 7. Votre message est publié et le producteur du jeu de données (ou de la réutilisation) reçoit une notification de son côté.


### PR DESCRIPTION
Close https://github.com/etalab/data.gouv.fr/issues/399.

Update doc to reflect frontend changes (following changes to udata3).

Additional changes:
- Updated some links that were down, better links can surely be found.
- Added schema description when uploading resources, help is welcome to improve it. We could also document schemas in `Télécharger une ressource`.
- Added MIME type for catalog pages.
- Added some warning but didn't update doc for pages that may change a lot in the near future (open for discussion).

