### PR TITLE
Fix Opendatasoft capitalization

### DIFF
--- a/articles/_moissonnage/ods.md
+++ b/articles/_moissonnage/ods.md
@@ -1,25 +1,25 @@
 ---
-title: OpenDataSoft
+title: Opendatasoft
 order: 4
 ---
 
-# Moissonnage OpenDataSoft
+# Moissonnage Opendatasoft
 
-## OpenDataSoft
+## Opendatasoft
 
-[OpenDataSoft](https://www.opendatasoft.com) est un service en PaaS permettant de mettre en œuvre ce qu'on appelle un datastore et le portail de données associé.
+[Opendatasoft](https://www.opendatasoft.com) est un service en PaaS permettant de mettre en œuvre ce qu'on appelle un datastore et le portail de données associé.
 
-Le moissonneur utilise l'API de chaque portail OpenDataSoft pour récupérer les métadonnées.
+Le moissonneur utilise l'API de chaque portail Opendatasoft pour récupérer les métadonnées.
 
 ## Spécifications techniques
 
-Ce moissonneur attend l'URL racine de votre portail OpenDataSoft. C'est bien l'URL publique (`https://data.ma-compagnie.com`) qui est attendue, et non l'URL noire OpenDataSoft (`https://ma-compagnie.opendatasoft.com`).
+Ce moissonneur attend l'URL racine de votre portail Opendatasoft. C'est bien l'URL publique (`https://data.ma-compagnie.com`) qui est attendue, et non l'URL noire Opendatasoft (`https://ma-compagnie.opendatasoft.com`).
 
-**Attention**: OpenDataSoft utilise le slug (la portion identifiant le jeu de données dans les URLs) comme identifiant technique. L'outil laisse la possibilité de changer ce slug ce qui pose un vrai problème de pérénité des identifiants. Ayez donc à l'esprit que ce changement d'identifiant créera des doublons au moissonnage.
+**Attention**: Opendatasoft utilise le slug (la portion identifiant le jeu de données dans les URLs) comme identifiant technique. L'outil laisse la possibilité de changer ce slug ce qui pose un vrai problème de pérénité des identifiants. Ayez donc à l'esprit que ce changement d'identifiant créera des doublons au moissonnage.
 
 ### Inspire
 
-Il est possible de filtrer les jeu de données identifiés comme venant d'Inspire par OpenDataSoft (propriété `interop_metas.inspire`).
+Il est possible de filtrer les jeu de données identifiés comme venant d'Inspire par Opendatasoft (propriété `interop_metas.inspire`).
 Pour cela il suffit de cocher ou non l'option **Inspire** du moissonneur.
 Cela permettra d'éviter des doublons pour les jeux de données déjà moissonnés par geo.data.gouv.fr.
 Il n'y a pas de règle universelle à son usage, c'est du cas par cas et il est de votre responsabilité de vérifier si ces jeux de données sont déjà pris en charge par `geo.data.gouv.fr`.
@@ -28,7 +28,7 @@ Il n'y a pas de règle universelle à son usage, c'est du cas par cas et il est 
 
 ### Jeu de données
 
-| | data.gouv.fr | OpenDataSoft | Notes |
+| | data.gouv.fr | Opendatasoft | Notes |
 |-|--------------|--------------|-------|
 | Title | `title` | `title` | |
 | Acronyme | `acronym` | ❌ | |
@@ -44,7 +44,7 @@ Il n'y a pas de règle universelle à son usage, c'est du cas par cas et il est 
 
 Certains champs sont conservés dans les attributs clés-valeurs `extras` par soucis de traçabilité :
 
-| | data.gouv.fr `extras` | OpenDataSoft | Notes |
+| | data.gouv.fr `extras` | Opendatasoft | Notes |
 |-|-----------------------|--------------|-------|
 | Identifiant distant | `harvest:remote_id` | `datasetid` | ⚠ Attention au changement |
 | URL de consultation | `ods:url` | `site`/explore/dataset/`datasetid`/ | |
@@ -55,16 +55,16 @@ Certains champs sont conservés dans les attributs clés-valeurs `extras` par so
 
 ### Ressources
 
-Il existe 3 types de ressources identifiés chez OpenDataSoft :
+Il existe 3 types de ressources identifiés chez Opendatasoft :
 - l'API de données qui donnera lieu à plusieurs ressource sur data.gouv.fr :
   - un export au format `CSV`
   - un export au format `JSON`
   - un export au format `GeoJSON` dans le cas de données spatiales
   - un export au format `Shapefile` dans le cas de données spatiales
-- les pièces jointes (`attachments` dans l'API OpenDataSoft) qui seront chacune reconnue comme une ressource
-- les exports alternatifs (`alternative_exports` dans l'API OpenDataSoft) qui seront chacun reconnu comme une ressource
+- les pièces jointes (`attachments` dans l'API Opendatasoft) qui seront chacune reconnue comme une ressource
+- les exports alternatifs (`alternative_exports` dans l'API Opendatasoft) qui seront chacun reconnu comme une ressource
 
 ## Contribuer
 
-Le moissonneur OpenDataSoft est publié sur github dans le plugin [`udata-ods`](https://github.com/opendatateam/udata-ods). Vous pouvez donc soumettre des améliorations ou signaler des anomalies.
+Le moissonneur Opendatasoft est publié sur github dans le plugin [`udata-ods`](https://github.com/opendatateam/udata-ods). Vous pouvez donc soumettre des améliorations ou signaler des anomalies.
 


### PR DESCRIPTION
## Summary 

The docs currently use the old text formatting "OpenDataSoft". This pull request updates occurrences of "OpenDataSoft" to "Opendatasoft" in the Opendatasoft documentation.

## Changes
- Updated occurrences of OpenDataSoft to Opendatasoft in the Opendatasoft documentation