### PR TITLE
Fix api reference doc

### DIFF
--- a/_layouts/swagger.html
+++ b/_layouts/swagger.html
@@ -3,7 +3,7 @@ layout: page
 ---
 {{ content }}
 
-<link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3/swagger-ui.css" />
+<link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@4/swagger-ui.css" />
 <style>
 /* Hide information container */
 .swagger-ui .information-container {
@@ -14,8 +14,8 @@ layout: page
 <!-- Swagger UI container -->
 <div id="swagger-ui"></div>
 
-<script src="//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
-<script src="//unpkg.com/swagger-ui-dist@3/swagger-ui-standalone-preset.js"></script>
+<script src="//unpkg.com/swagger-ui-dist@4/swagger-ui-bundle.js"></script>
+<script src="//unpkg.com/swagger-ui-dist@4/swagger-ui-standalone-preset.js"></script>
 <script>
 const ui = SwaggerUIBundle({
   url: '{{ page.specs }}',

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -62,3 +62,7 @@ ul {
 .alert > p {
   display: inline;
 }
+
+.swagger-ui code {
+  background-color: var(--darker-grey);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   web:
-    image: jekyll/jekyll:latest
+    image: jekyll/jekyll:3
     command: jekyll serve --watch --force_polling -H 0.0.0.0 -P 4000
     ports:
       - 4000:4000


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/192
Fix https://github.com/etalab/data.gouv.fr/issues/914

Tried to fix both bugs mentioned in https://github.com/etalab/doc.data.gouv.fr/issues/85 but could not reproduce.

I set the jekyll image to 3 in docker-compose, but we could also upgrade deps in .lock to work with an upgrade version of jekyll and bundler. In the case of an upgrade, we should check how those versions are managed in github pages deployment.